### PR TITLE
Automatically include controllers and middlewares in sub-directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Really lightweight wrapper around express to help you make a neat app from day o
 }
 ```
 
+All files in controllers and middleware directories will be included automatically, except for files and folders starting with `_`.
+
 ##Example app
 ```
 server.js

--- a/index.js
+++ b/index.js
@@ -86,13 +86,18 @@ APIServer.prototype.start = function start() {
     walk(controllersBase).forEach(function(file) {
         if(file.substr(file.length-3) == '.js') {
             var controllerFile = require(controllersBase + '/' + file);
+            
+            if( /(\/|^)_/.test(file) ) {
+                // Ignore files and directories beginning with _
+                return self.debug('Ignored private file %s', file);
+            }
 
             if(typeof(controllerFile.controller) === 'function') {
                 controllerFile.controller(self);
                 self.debug('Loaded controller in file', file);
             }
             else {
-                self.debug('Ignored', file, 'as no controller function was exported');
+                self.debug('Ignored %s as no controller function was exported', file);
             }
         }
     });


### PR DESCRIPTION
It's easy-server, but it should be easier.

Files and folders beginning with `_` will be ignored.
